### PR TITLE
fix vetmed name

### DIFF
--- a/hsl/location_facet.json
+++ b/hsl/location_facet.json
@@ -1,6 +1,7 @@
 {
     "hsl" : "Health Sciences Libraries",
     "hsluncy" : "UNC Health Sciences Library",
+    "hslncsuvetmed": "NCSU Veterinary Medicine",
     "hsldukr" : "Duke Medical Center",
     "hsldukrares" : "Archives",
     "hsldukrhiry" : "History",


### PR DESCRIPTION
Add mapping for NCSU Vet. Med. library to HSL hierarchy.